### PR TITLE
Update signatures for Unbound

### DIFF
--- a/lib/Net/DNS/Fingerprint.pm
+++ b/lib/Net/DNS/Fingerprint.pm
@@ -114,9 +114,12 @@ my @iq = (
     "1,UPDATE,0,0,1,1,0,0,FORMERR,0,0,0,0",           #iq20
     "1,QUERY,0,0,1,1,0,0,NOERROR,.+,.+,.+,.+",        #iq21
     "1,QUERY,0,1,1,1,0,0,NOERROR,.+,.+,.+,.+",        #iq22
-    "1,QUERY,0,0,0,0,0,0,REFUSED,0,0,0,0",            #iq23
-    "1,QUERY,0,0,1,1,0,0,REFUSED,1,0,0,0",            #iq24
-    "1,QUERY,0,0,1,1,0,0,NXDOMAIN,.+,.+,.+,.+",       #iq25
+    "1,QUERY,0,0,0,.+,0,0,REFUSED,.+,0,0,0",          #iq23
+    "1,QUERY,0,0,0,0,0,0,REFUSED,0,0,0,0",            #iq24
+    "1,QUERY,0,0,0,1,0,0,REFUSED,1,0,0,0",            #iq25
+    "1,QUERY,0,0,1,1,0,0,REFUSED,1,0,0,0",            #iq26
+    "1,QUERY,0,0,1,1,0,0,NXDOMAIN,.+,.+,.+,.+",       #iq27
+    "1,QUERY,0,0,1,0,0,0,FORMERR,1,0,0,0",            #iq28
 );
 
 my @ruleset = (
@@ -375,43 +378,65 @@ my @ruleset = (
     },
     {
         fingerprint => $iq[23],
-        header      => $qy[10],
-        query       => $nct[10],
+        header      => $qy[0],
+        query       => $nct[0],
         ruleset     => [
             {
                 fingerprint => $iq[24],
-                result      => {
-                    vendor  => "NLnetLabs",
-                    product => "Unbound",
-                    version => "1.3.0 -- 1.4.0"
-                },
+                header      => $qy[10],
+                query       => $nct[10],
+                ruleset     => [
+                    {
+                        fingerprint => $iq[26],
+                        result      => {
+                            vendor  => "NLnetLabs",
+                            product => "Unbound",
+                            version => "1.3.0 -- 1.4.0"
+                        },
+                    },
+                    {
+                        fingerprint => $iq[27],
+                        header      => $qy[11],
+                        query       => $nct[11],
+                        ruleset     => [
+                            {
+                                fingerprint => "header section incomplete",
+                                result      => {
+                                    vendor  => "NLnetLabs",
+                                    product => "Unbound",
+                                    version => "1.4.1 -- 1.4.9"
+                                },
+                            },
+                            {
+                                fingerprint => $iq[19],
+                                result      => {
+                                    vendor  => "NLnetLabs",
+                                    product => "Unbound",
+                                    version => "1.4.10 -- 1.6.0"
+                                },
+                            },
+                            { fingerprint => ".+", state => "q0r3r23q10r25q11r?" },
+                        ]
+                    },
+                ],
             },
             {
                 fingerprint => $iq[25],
-                header      => $qy[11],
-                query       => $nct[11],
+                header      => $qy[10],
+                query       => $nct[10],
                 ruleset     => [
                     {
-                        fingerprint => "header section incomplete",
+                        fingerprint => $iq[28],
                         result      => {
                             vendor  => "NLnetLabs",
                             product => "Unbound",
-                            version => "1.4.1 -- 1.4.9"
+                            version => "1.7.0 -- 1.9.6"
                         },
                     },
-                    {
-                        fingerprint => $iq[19],
-                        result      => {
-                            vendor  => "NLnetLabs",
-                            product => "Unbound",
-                            version => "1.4.10 -- 1.6.0"
-                        },
-                    },
-                    { fingerprint => ".+", state => "q0r3r23q10r25q11r?" },
-                ]
+                ],
             },
         ]
-    },
+    }
 );
 
 my @qy_old = (

--- a/lib/Net/DNS/Fingerprint.pm
+++ b/lib/Net/DNS/Fingerprint.pm
@@ -404,7 +404,7 @@ my @ruleset = (
                         result      => {
                             vendor  => "NLnetLabs",
                             product => "Unbound",
-                            version => "1.4.10 -- 1.4.12"
+                            version => "1.4.10 -- 1.6.0"
                         },
                     },
                     { fingerprint => ".+", state => "q0r3r23q10r25q11r?" },


### PR DESCRIPTION
Hello,

This change updates the signatures for Unbound. The existing signatures matched up to (including) 1.6.0, so that's a simple fix. Between 1.6.1 and 1.6.8, fpdns identifies Unbound as "Raiden DNSD" (even after this change). For 1.7.0 and later, I've added new rules.

To verify this, I've built all versions of unbound I was able to, which turns out are all Unbound from 1.5.10 and later (openssl api changes made it harder to travel further back in time). I have not tested the new rules on other nameservers, other than one version of NSD.

Let me know if this type of change is reasonable and would be happy to try to use the same methodology to update nsd signatures as well.

Prior to this change:
```
1.5.10: NLnetLabs Unbound 1.4.10 -- 1.4.12 [New Rules]  
1.6.0: NLnetLabs Unbound 1.4.10 -- 1.4.12 [New Rules]  
1.6.1: Raiden DNSD  [Old Rules]  
1.6.2: Raiden DNSD  [Old Rules]  
1.6.3: Raiden DNSD  [Old Rules]  
1.6.4: Raiden DNSD  [Old Rules]  
1.6.5: Raiden DNSD  [Old Rules]  
1.6.6: Raiden DNSD  [Old Rules]  
1.6.7: Raiden DNSD  [Old Rules]  
1.6.8: Raiden DNSD  [Old Rules]  
1.7.0: Raiden DNSD  [Old Rules]  
1.7.1: No match found  
1.7.2: No match found  
1.7.3: No match found  
1.8.0: No match found  
1.8.1: No match found  
1.8.2: No match found  
1.8.3: No match found  
1.9.0: No match found  
1.9.1: No match found  
1.9.2: No match found  
1.9.3: No match found  
1.9.4: No match found  
1.9.5: No match found  
1.9.6: No match found  
```

With this change:
```
1.5.10: NLnetLabs Unbound 1.4.10 -- 1.6.0 [New Rules]  
1.6.0: NLnetLabs Unbound 1.4.10 -- 1.6.0 [New Rules]  
1.6.1: Raiden DNSD  [Old Rules]  
1.6.2: Raiden DNSD  [Old Rules]  
1.6.3: Raiden DNSD  [Old Rules]  
1.6.4: Raiden DNSD  [Old Rules]  
1.6.5: Raiden DNSD  [Old Rules]  
1.6.6: Raiden DNSD  [Old Rules]  
1.6.7: Raiden DNSD  [Old Rules]  
1.6.8: Raiden DNSD  [Old Rules]  
1.7.0: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.7.1: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.7.2: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.7.3: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.8.0: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.8.1: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.8.2: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.8.3: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.9.0: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.9.1: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.9.2: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.9.3: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.9.4: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.9.5: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
1.9.6: NLnetLabs Unbound 1.7.0 -- 1.9.6 [New Rules]  
```