### PR TITLE
Fingerprint nsd 4.3.1 + tree structure

### DIFF
--- a/lib/Net/DNS/Fingerprint.pm
+++ b/lib/Net/DNS/Fingerprint.pm
@@ -120,6 +120,8 @@ my @iq = (
     "1,QUERY,0,0,1,1,0,0,REFUSED,1,0,0,0",            #iq26
     "1,QUERY,0,0,1,1,0,0,NXDOMAIN,.+,.+,.+,.+",       #iq27
     "1,QUERY,0,0,1,0,0,0,FORMERR,1,0,0,0",            #iq28
+    "1,QUERY,0,0,0,0,0,0,REFUSED,1,0,0,0",            #iq29
+    "1,$NOTIFY,0,0,1,0,0,0,FORMERR,0,0,0,0",          #iq30
 );
 
 my @ruleset = (
@@ -143,6 +145,21 @@ my @ruleset = (
             product => "Eagle DNS",
             version => "1.0 -- 1.0.1"
         },
+    },
+    {
+        fingerprint => $iq[29],
+        header      => $qy[2],
+        query       => $nct[2],
+        ruleset     => [
+            {
+                fingerprint => $iq[30],
+                result      => {
+                    vendor  => "NLnetLabs",
+                    product => "NSD",
+                    version => "4.1.10 -- 4.3.1"
+                },
+            },
+        ],
     },
     {
         fingerprint => $iq[3],


### PR DESCRIPTION
Hello,

This pull request adds signatures for nsd 4.1.10 -- 4.3.1 (the range I tested, probably earlier versions as well; 4.3.1 is currently the latest released version). The change supersedes earlier legacy signatures for "3Com Office Connect Remote".

In the change, I add one signature to aggregate several other signatures (those of a previous nsd signature and two signatures for Unlogic EagleDNS), even though that isn't necessary for the matcher to work. The reason for this is to make it slightly easier to reason about, when e.g. introducing a new signature that only varies (in this case) on the RCODE. This way the "top level" of rules doesn't necessarily grow uncontrollably.

The drawback of this is that it can generate unnecessary repeated queries. I realize this is already the case for the unbound signature updates I contributed earlier, but I have a separate change that could possibly address that by introducing simple (perl level) caching (actual code changes, not boring signatures ;)).