### PR TITLE
Implement simple query caching to avoid repeating questions

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,7 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     'NAME'         => 'Net::DNS::Fingerprint',
     'VERSION_FROM' => 'lib/Net/DNS/Fingerprint.pm',
+    'MIN_PERL_VERSION' => '5.10.0',
     'PREREQ_PM'    => { Net::DNS => 0.42 },
     'EXE_FILES'    => ["apps/fpdns"],
     'NO_META'      => 1,


### PR DESCRIPTION
When writing rules, one may want to organize queries in a way that would cause redundant queries being sent to the probed target. By adding this caching mechanism, one can write rules without having to worry about this. This change depends on the "state" feature of Perl, available since Perl 5.10.

This change assumes that signature matches aren't affected by query order or the ability to repeat queries. I tried to glance over the existing signatures to see if that was the case and couldn't find any instances (from what I could tell each branch always varied header and/or query) but let me know if this assumption is invalid.